### PR TITLE
fix: Change CI badge to right directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
         :target: https://github.com/psf/black
 
 .. |CI| image:: https://github.com/diffpy/diffpy.cmi/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
-        :target: https://github.com/diffpy/diffpy.cmi/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
+        :target: https://github.com/diffpy/diffpy.srxplanar/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
 
 .. |Codecov| image:: https://codecov.io/gh/diffpy/diffpy.srxplanar/branch/main/graph/badge.svg
         :target: https://codecov.io/gh/diffpy/diffpy.srxplanar

--- a/news/readme-fix.rst
+++ b/news/readme-fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news needed: changes CI in README.rst to right direction.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge Ready to review, Previously I followed `diffpy.cmi` README.rst to fix, but I forgot to change the directory to `diffpy.srxplanar`
