### PR TITLE
chore: add path to example file to successfully build conda-forge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
 graft src
 graft tests
 graft requirements
+graft docs/examples
 
 include AUTHORS.rst LICENSE*.rst README.rst
-include docs/examples/data/KFe2As2-00838.tif
 
 # Exclude all bytecode files and __pycache__ directories
 global-exclude *.py[cod]  # Exclude all .pyc, .pyo, and .pyd files.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ graft tests
 graft requirements
 
 include AUTHORS.rst LICENSE*.rst README.rst
+include docs/examples/data/KFe2As2-00838.tif
 
 # Exclude all bytecode files and __pycache__ directories
 global-exclude *.py[cod]  # Exclude all .pyc, .pyo, and .pyd files.

--- a/news/MANIFEST.rst
+++ b/news/MANIFEST.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Change MANIFEST.in to build conda-forge
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge Ready to review. I made this PR because `conda-forge` cannot find the example file correctly.